### PR TITLE
fix markdown for get started button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ This is a simple guessing game to play with Alexa. You guess a number, she tells
 If you’re in the US, we've also included the new [speechcons](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/speechcon-reference) feature for Alexa skill development. Speechcons are special words and phrases that Alexa pronounces more expressively. We use them in this quiz game to let the user know whether they gave a correct or incorrect answer during the quiz.
 
 
- href="./instructions/1-voice-user-interface.md"><img src="https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/tutorials/general/buttons/button_get_started._TTH_.png" /></a>
+[![Get Started!](https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/tutorials/general/buttons/button_get_started._TTH_.png)](./instructions/1-voice-user-interface.md)
 
 <img height="1" width="1" src="https://www.facebook.com/tr?id=1847448698846169&ev=PageView&noscript=1"/>


### PR DESCRIPTION
The **Get Started** link in _README.md_ didn't work because it was written in HTML and forwarded to the image of the button itself.