### PR TITLE
fix error in ErrorHandler

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -266,7 +266,7 @@ exports.handler = skillBuilder
     FallbackHandler,
     UnhandledIntent,
   )
-  .addErrorHandlers(ErrorHandler)
+  //.addErrorHandlers(ErrorHandler)
   .withTableName('High-Low-Game')
   .withAutoCreateTable(true)
   .lambda();


### PR DESCRIPTION
Comment out error handler used in 1,0

*Issue #34 

*Description of changes:*
When using in non-US locations, English-UK Europe even though English-US selected when building using ASK-CLI there appears a clash with the error handler, because FALLBACK is not used outside US

So I have commented out the Error Handlers registration and now this skill works and the pull request reflects this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
