### PR TITLE
Correcting Order of Calling Intent Functions

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -280,14 +280,14 @@ exports.handler = skillBuilder
   .withPersistenceAdapter(getPersistenceAdapter(ddbTableName))
   .addRequestHandlers(
     LaunchRequest,
-    ExitHandler,
-    SessionEndedRequest,
     HelpIntent,
     YesIntent,
     NoIntent,
     NumberGuessIntent,
     FallbackHandler,
     UnhandledIntent,
+    ExitHandler,
+    SessionEndedRequest,
   )
   .addErrorHandlers(ErrorHandler)
   .lambda();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Exit and Session End Function should be called at last because the sequence of calling functions matter in lambda.
Like if There's no match, then it'll directly go to exitIntent Function and that will be incorrect. So these two functions should be called after all intents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
